### PR TITLE
Adding rebounds method to Dribbble::Shot

### DIFF
--- a/lib/dribbble/shot.rb
+++ b/lib/dribbble/shot.rb
@@ -14,6 +14,10 @@ module Dribbble
       paginated_list(get("/shots/#{@id}/comments", :query => options))
     end
 
+    def rebounds(options={})
+      paginated_list(get("/shots/#{@id}/rebounds", :query => options))
+    end
+
     # Options: :page, :per_page
     def self.debuts(options={})
       paginated_list(get("/shots/debuts", :query => options))

--- a/test/shot_test.rb
+++ b/test/shot_test.rb
@@ -48,6 +48,13 @@ class ShotTest < Test::Unit::TestCase
     comments.each { |c| assert c.is_a?(Dribbble::Comment), "#{c.inspect} is not a Dribbble::Comment." }
   end
 
+  def test_rebounds
+    shot = Dribbble::Shot.find(21595)
+    rebounds = shot.rebounds
+    assert rebounds.is_a?(Dribbble::PaginatedList), "#{rebounds.inspect} is not a Dribbble::PaginatedList."
+    rebounds.each { |r| assert r.is_a?(Dribbble::Shot), "#{r.inspect} is not a Dribbble::Shot." }
+  end
+
   def test_debuts
     shots = Dribbble::Shot.debuts
     assert_kind_of Array, shots


### PR DESCRIPTION
Hey, I just added a rebounds method to Dribbble::Shot to cover the equivalent API call.
