### PR TITLE
Raise PlayerNotFound exception if player not found

### DIFF
--- a/lib/dribbble/player.rb
+++ b/lib/dribbble/player.rb
@@ -1,30 +1,40 @@
 module Dribbble
   class Player < Base
+    def self.fetch(url, options = {})
+      user = get(url, options)
+
+      if user.response.is_a?(Net::HTTPOK)
+        user
+      else
+        raise PlayerNotFound
+      end
+    end
+
     def self.find(id)
-      new(get("/players/#{id}"))
+      new(fetch("/players/#{id}"))
     end
 
     # Fetches this player's shots.
     # Options: :page, :per_page
     def shots(options={})
-      paginated_list(self.class.get("/players/#{@id}/shots", :query => options))
+      paginated_list(self.class.fetch("/players/#{@id}/shots", :query => options))
     end
 
     # Fetches shots by players that this player follows.
     def shots_following(options={})
-      paginated_list(self.class.get("/players/#{@id}/shots/following", :query => options))
+      paginated_list(self.class.fetch("/players/#{@id}/shots/following", :query => options))
     end
 
     def draftees(options={})
-      paginated_list(self.class.get("/players/#{@id}/draftees", :query => options))
+      paginated_list(self.class.fetch("/players/#{@id}/draftees", :query => options))
     end
 
     def followers(options={})
-      paginated_list(self.class.get("/players/#{@id}/followers", :query => options))
+      paginated_list(self.class.fetch("/players/#{@id}/followers", :query => options))
     end
 
     def following(options={})
-      paginated_list(self.class.get("/players/#{@id}/following", :query => options))
+      paginated_list(self.class.fetch("/players/#{@id}/following", :query => options))
     end
   end
 end

--- a/lib/dribbble/player.rb
+++ b/lib/dribbble/player.rb
@@ -3,10 +3,10 @@ module Dribbble
     def self.fetch(url, options = {})
       user = get(url, options)
 
-      if user.response.is_a?(Net::HTTPOK)
-        user
-      else
+      if user.response.is_a?(Net::HTTPNotFound)
         raise PlayerNotFound
+      else
+        user
       end
     end
 

--- a/lib/swish.rb
+++ b/lib/swish.rb
@@ -4,3 +4,7 @@ require 'dribbble/base'
 require 'dribbble/comment'
 require 'dribbble/shot'
 require 'dribbble/player'
+
+module Dribbble
+  class PlayerNotFound < Exception; end
+end

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -23,6 +23,12 @@ class PlayerTest < Test::Unit::TestCase
     end
   end
 
+  def test_finding_invalid_user
+    assert_raises(Dribbble::PlayerNotFound) do
+      Dribbble::Player.find(999999)
+    end
+  end
+
   def test_shots
     player = Dribbble::Player.find(1)
     shots = player.shots


### PR DESCRIPTION
Right now there is no check to ensure the response is valid and the user actually exists. The only way to find out now is to do something like:

``` ruby
player = Dribbble::Player.find('garrettb')
player.id # => raises NoMethodError
```

Not a good control flow when determining if the user is valid or not. This now will raise a new Dribbble::PlayerNotFound exception if the response is a 404.

``` ruby
Dribbble::Player.find('garrettb') # => raises Dribbble::PlayerNotFound
```
