### PR TITLE
s/has_key/key/

### DIFF
--- a/lib/dribbble/paginated_list.rb
+++ b/lib/dribbble/paginated_list.rb
@@ -8,9 +8,9 @@ module Dribbble
       @page = results['page']
 
       result_key, result_class = 
-        if results.has_key?('shots')
+        if results.key?('shots')
           ['shots', Dribbble::Shot]
-        elsif results.has_key?('players')
+        elsif results.key?('players')
           ['players', Dribbble::Player]
         else
           ['comments', Dribbble::Comment]

--- a/test/paginated_list_test.rb
+++ b/test/paginated_list_test.rb
@@ -60,4 +60,14 @@ class PaginatedListTest < Test::Unit::TestCase
     assert_equal 2, list.size
     list.each { |p| assert p.is_a?(Dribbble::Comment), "#{p.inspect} is not a Dribbble::Comment" }
   end
+
+  def test_real_life
+    per_page = 30
+    page_count = Dribbble::Base.paginated_list(Dribbble::Base.get("/players/icco/shots/likes", :query => {:per_page => per_page})).pages
+    (1..page_count).each do |page|
+      list = Dribbble::Base.paginated_list(Dribbble::Base.get("/players/icco/shots/likes", :query => {:page => page, :per_page => per_page}))
+      assert_equal per_page, list.size if page < page_count
+      list.each { |p| assert p.is_a?(Dribbble::Shot), "#{p.inspect} is not a Dribbble::Shot" }
+    end
+  end
 end


### PR DESCRIPTION
As of ruby 2.0, HTTPHeader (and thus httpparty https://github.com/jnunemaker/httparty/blob/master/lib/httparty/response/headers.rb) does not have `has_key?` http://ruby-doc.org/stdlib-2.0.0/libdoc/net/http/rdoc/Net/HTTPHeader.html#method-i-key-3F
